### PR TITLE
Added warning about API V1 deprecation

### DIFF
--- a/mgmt/rest/log_handler.go
+++ b/mgmt/rest/log_handler.go
@@ -22,8 +22,6 @@ package rest
 import (
 	"net/http"
 
-	"strconv"
-
 	log "github.com/Sirupsen/logrus"
 	"github.com/urfave/negroni"
 )
@@ -52,17 +50,14 @@ func (l *Logger) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.Ha
 		"method":      r.Method,
 		"url":         r.URL.Path,
 		"status-code": res.Status(),
-		"status":      deprecated(http.StatusText(res.Status()), rw.Header().Get("Deprecated"), rw.Header().Get("DeprWhat"), rw.Header().Get("DeprInfo")),
+		"status":      http.StatusText(res.Status()),
 	}).Debug("API response")
-}
 
-// 'deprecate' is string boolean value to deprecate, mapped to 'Deprecated' key
-// 'deprWhat' is what is being deprecated, mapped to 'DeprWhat' key
-// 'deprInfo' is link to more information on what is being deprecated, mapped to 'DeprInfo' key
-func deprecated(status string, deprecate string, deprWhat string, deprInfo string) string {
-	dep, err := strconv.ParseBool(deprecate)
-	if err != nil || !dep {
-		return status
+	if deprecationInfo := rw.Header().Get("Deprecated"); len(deprecationInfo) != 0 {
+		restLogger.WithFields(log.Fields{
+			"method": r.Method,
+			"url":    r.URL.Path,
+		}).Warning(deprecationInfo)
 	}
-	return status + ". '" + deprWhat + "' has been depricated. Find more information here: " + deprInfo
+
 }

--- a/mgmt/rest/v1/rbody/body.go
+++ b/mgmt/rest/v1/rbody/body.go
@@ -32,6 +32,8 @@ import (
 	"github.com/urfave/negroni"
 )
 
+const deprecationInfo = "API V1 has been depricated. Find more information here: https://github.com/intelsdi-x/snap/issues/1637"
+
 type Body interface {
 	// These function names are rather verbose to avoid field vs function namespace collisions
 	// with varied object types that use them.
@@ -40,10 +42,7 @@ type Body interface {
 }
 
 func Write(code int, b Body, w http.ResponseWriter) {
-	deprStrBool, deprWhat, deprInfo := "true", "apiV1", "https://github.com/intelsdi-x/snap/issues/1637"
-	w.Header().Set("Deprecated", deprStrBool)
-	w.Header().Set("DeprWhat", deprWhat)
-	w.Header().Set("DeprInfo", deprInfo)
+	w.Header().Set("Deprecated", deprecationInfo)
 
 	resp := &APIResponse{
 		Meta: &APIResponseMeta{


### PR DESCRIPTION
@aarontay, use it or not - up to you

Summary of changes:
- warning about API V1 deprecation
- removed function `deprecated`, do all things more straightforward

![image](https://cloud.githubusercontent.com/assets/11335874/26330792/f2eb2e0a-3f4d-11e7-978d-a5ac4107716d.png)

